### PR TITLE
[approval workflow]: refs #8

### DIFF
--- a/ckanext/ed/controller.py
+++ b/ckanext/ed/controller.py
@@ -1,8 +1,15 @@
+import logging
 import os
-from ckan.plugins import toolkit
-from ckanext.ed.helpers import get_storage_path_for
+
+from ckan import model
 from ckan.common import response
 from ckan.lib import base
+from ckan.logic.action import delete as delete_core
+from ckan.logic.action import get as get_core
+from ckan.logic.action import patch as patch_core
+from ckan.plugins import toolkit
+from ckanext.ed.helpers import get_storage_path_for
+from ckanext.ed.mailer import mail_package_publish_update_to_user
 
 
 class DownloadController(base.BaseController):
@@ -25,3 +32,36 @@ class DownloadController(base.BaseController):
         response.headers['Content-Type'] = 'application/octet-stream'
         response.content_disposition = 'attachment; filename=' + package_name
         os.remove(file_path)
+
+
+class PublishControler(base.BaseController):
+    def approve(self, id):
+        # check access and state
+        _raise_not_authz_or_not_pending(id)
+        data_dict = patch_core.package_patch({}, {'id': id, 'state': 'active'})
+        mail_package_publish_update_to_user({}, data_dict, event='approval')
+
+        # show flash message and redirect
+        toolkit.h.flash_success('Dataset "{}" approved'.format(data_dict['title']))
+        toolkit.redirect_to(controller='package', action='read', id=data_dict['name'])
+
+    def reject(self, id, *args, **kwargs):
+        # check access and state
+        _raise_not_authz_or_not_pending(id)
+        data_dict = get_core.package_show({'model': model}, {'id': id})
+        mail_package_publish_update_to_user({}, data_dict, event='rejection')
+        delete_core.dataset_purge({'model': model}, {'id': id})
+
+        # show flash message and redirect
+        toolkit.h.flash_error('Dataset "{}" rejected'.format(data_dict['title']))
+        toolkit.redirect_to('/dataset')
+
+
+def _raise_not_authz_or_not_pending(id):
+    # check auth with toolkit.check_access
+    toolkit.check_access('sysadmin', {'model': model})
+
+    # check org exists and it's pending with organization_show
+    data_dict = toolkit.get_action('package_show')({}, {'id': id})
+    if data_dict.get('state') != 'approval_needed':
+        raise toolkit.ObjectNotFound('Dataset "{}" not found'.format(id))

--- a/ckanext/ed/mailer.py
+++ b/ckanext/ed/mailer.py
@@ -1,0 +1,50 @@
+import logging
+from ckan import model
+from ckan.common import config
+from ckan.plugins import toolkit
+from ckan.lib.mailer import mail_user
+from ckan.lib.base import render_jinja2
+import ckan.logic.action.get as get_core
+log = logging.getLogger(__name__)
+
+
+def mail_package_publish_request_to_sysadmins(context, data_dict):
+    context.setdefault('model', model)
+    # Mail all sysadmins
+    for user in _get_sysadmins(context):
+        if user.email:
+            subj = _compose_email_subj(data_dict, event='request')
+            body = _compose_email_body(data_dict, user, event='request')
+            mail_user(user, subj, body)
+            log.debug('[email] Pakcage publishing request email sent to {0}'.format(user.name))
+
+
+def mail_package_publish_update_to_user(context, pkg_dict, event='approval'):
+    context.setdefault('model', model)
+    user = model.User.get(pkg_dict['creator_user_id'])
+    if user and user.email:
+        subj = _compose_email_subj(pkg_dict, event=event)
+        body = _compose_email_body(pkg_dict, user, event=event)
+        mail_user(user, subj, body)
+        log.debug('[email] Data container update email sent to {0}'.format(user.name))
+
+
+def _get_sysadmins(context):
+    model = context['model']
+    return model.Session.query(model.User).filter(model.User.sysadmin==True).all()
+
+
+def _compose_email_subj(data_dict, event='request'):
+    return '[US ED] Package Publishing {0}: {1}'.format(event.capitalize(), data_dict['title'])
+
+
+def _compose_email_body(data_dict, user, event='request'):
+    pkg_link = toolkit.url_for('dataset_read', id=data_dict['name'], qualified=True)
+    return render_jinja2('emails/package_publish_{0}.txt'.format(event), {
+        'user_name': user.fullname or user.name,
+        'site_title': config.get('ckan.site_title'),
+        'site_url': config.get('ckan.site_url'),
+        'package_title': data_dict['title'],
+        'package_link': pkg_link,
+        'publisher_name': data_dict.get('contact_name')
+    })

--- a/ckanext/ed/plugin.py
+++ b/ckanext/ed/plugin.py
@@ -23,10 +23,10 @@ class EDPlugin(plugins.SingletonPlugin, DefaultTranslation):
         }
 
     # IActions
-
     def get_actions(self):
         return {
             'ed_prepare_zip_resources': actions.prepare_zip_resources,
+            'dataset_create': actions.dataset_create
         }
 
     # IConfigurer
@@ -39,6 +39,13 @@ class EDPlugin(plugins.SingletonPlugin, DefaultTranslation):
     # IRoutes
 
     def before_map(self, map):
+        publish_controller = 'ckanext.ed.controller:PublishControler'
+        map.connect('/dataset-publish/{id}/approve',
+                     controller=publish_controller,
+                     action='approve')
+        map.connect('/dataset-publish/{id}/reject',
+                     controller=publish_controller,
+                     action='reject')
         map.connect(
             'download_zip',
             '/download/zip/{zip_id}',

--- a/ckanext/ed/templates/emails/package_publish_approval.txt
+++ b/ckanext/ed/templates/emails/package_publish_approval.txt
@@ -1,0 +1,14 @@
+Dear {{ publisher_name }},
+
+The dataset publishing request for "{{ package_title }}" has been approved.
+
+You can view and manage the dataset on the following page after logging in to the site:
+
+   {{ package_link }}
+
+Have a nice day.
+
+
+--
+Message sent by {{ site_title }} ({{ site_url }})
+This is an automated message, please don't respond to this address.

--- a/ckanext/ed/templates/emails/package_publish_rejection.txt
+++ b/ckanext/ed/templates/emails/package_publish_rejection.txt
@@ -1,0 +1,12 @@
+Dear {{ publisher_name }},
+
+The dataset publishing request for "{{ package_title }}" has been rejected.
+
+Please contact the site administrators for the further information.
+
+Have a nice day.
+
+
+--
+Message sent by {{ site_title }} ({{ site_url }})
+This is an automated message, please don't respond to this address.

--- a/ckanext/ed/templates/emails/package_publish_request.txt
+++ b/ckanext/ed/templates/emails/package_publish_request.txt
@@ -1,0 +1,17 @@
+Dear {{ user_name }},
+
+A new package has been requested for publishing:
+
+    {{ package_title }}
+
+To approve or reject the request, please visit the following page (logged in as a site administrator):
+
+    {{ package_link }}
+
+Have a nice day.
+
+
+
+--
+Message sent by {{ site_title }} ({{ site_url }})
+This is an automated message, please don't respond to this address.

--- a/ckanext/ed/templates/package/new_package_form.html
+++ b/ckanext/ed/templates/package/new_package_form.html
@@ -1,0 +1,32 @@
+{% extends 'package/snippets/package_form.html' %}
+
+{% block stages %}
+  {% if form_style != 'edit' %}
+    <div class="alert alert-warning" role="alert">
+      <p>
+        {% trans %}<strong>Note:</strong> This dataset will be submited for an administrator approval!{% endtrans %}
+      </p>
+    </div>
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
+{% block save_button_text %}
+  {% if form_style != 'edit' %}
+    {{ super() }}
+  {% else %}
+    {{ _('Update Dataset') }}
+  {% endif %}
+{% endblock %}
+
+{% block cancel_button %}
+  {% if form_style != 'edit' %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}
+
+{% block delete_button %}
+  {% if form_style == 'edit' and h.check_access('package_delete', {'id': pkg_dict.id}) %}
+    {{ super() }}
+  {% endif %}
+{% endblock %}

--- a/ckanext/ed/templates/package/read.html
+++ b/ckanext/ed/templates/package/read.html
@@ -1,0 +1,60 @@
+{% extends "package/read_base.html" %}
+
+{% block primary_content_inner %}
+  {{ super() }}
+  {% if c.pkg_dict.state  == 'approval_needed' %}
+    <div class="alert alert-warning" role="alert">
+      <p>{% trans %}This dataset is waiting for an administrator approval{% endtrans %}</p>
+    </div>
+    {% if h.check_access('sysadmin') %}
+      <a href="/dataset-publish/{{ c.pkg_dict.id }}/approve" class="btn btn-primary">
+        {% trans %}Approve Dataset{% endtrans %}
+      </a>
+      <a href="/dataset-publish/{{ c.pkg_dict.id }}/reject" class="btn btn-danger">
+        {% trans %}Reject Dataset{% endtrans %}
+      </a>
+    {% endif %}
+  {% else %}
+    {% block package_description %}
+      {% if pkg.private %}
+        <span class="dataset-private label label-inverse pull-right">
+          <i class="fa fa-lock"></i>
+          {{ _('Private') }}
+        </span>
+      {% endif %}
+      <h1>
+        {% block page_heading %}
+          {{ h.dataset_display_name(pkg) }}
+          {% if pkg.state.startswith('draft') %}
+            [{{ _('Draft') }}]
+          {% endif %}
+          {% if pkg.state == 'deleted' %}
+            [{{ _('Deleted') }}]
+          {% endif %}
+        {% endblock %}
+      </h1>
+      {% block package_notes %}
+        {% if pkg.notes %}
+          <div class="notes embedded-content">
+            {{ h.render_markdown(h.get_translated(pkg, 'notes')) }}
+          </div>
+        {% endif %}
+      {% endblock %}
+      {# FIXME why is this here? seems wrong #}
+      <span class="insert-comment-thread"></span>
+    {% endblock %}
+
+    {% block package_resources %}
+      {% snippet "package/snippets/resources_list.html", pkg=pkg, resources=pkg.resources %}
+    {% endblock %}
+
+    {% block package_tags %}
+      {% snippet "package/snippets/tags.html", tags=pkg.tags %}
+    {% endblock %}
+
+    {% block package_additional_info %}
+      {% snippet "package/snippets/additional_info.html", pkg_dict=pkg %}
+    {% endblock %}
+  {% endif %}
+
+{% endblock %}


### PR DESCRIPTION
PR is still WIP as it does not include tests yet. But besides tests, the code is ready to be reviewed. @amercader your feedback would be really helpful

- Override dataset_create and patch pending flag
  - approve package before publish
  - nobody but sysadmin can create package directly
  - if not sysadmin package is flagged as pending/not_approved
- Mailer to handle Emails
  - Request Email sent to all sysadmins
  - Template for request Email
- Approove/reject conrollers
  - buttons on dataset page for sysadmins to approve or reject
  - Templates for approve and reject Emails
  - Include package Url, title and publisher in Email
  - Worn users about submission VS publish